### PR TITLE
feat: api, redux 기본 구조 구현

### DIFF
--- a/kh/src/api/commentApi.js
+++ b/kh/src/api/commentApi.js
@@ -1,0 +1,16 @@
+import { instance } from './index';
+
+export async function fetchGet() {
+  const response = await instance.get('/comment');
+  return response;
+}
+
+export async function fetchDelete(id) {
+  const response = await instance.delete('/comment', id);
+  return response;
+}
+
+export async function fetchModify(id) {
+  const response = await instance.put('/comment', id);
+  return response;
+}

--- a/kh/src/api/index.js
+++ b/kh/src/api/index.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+export const instance = axios.create({
+  baseURL: BASE_URL,
+});

--- a/kh/src/redux/actions/comment.js
+++ b/kh/src/redux/actions/comment.js
@@ -1,0 +1,29 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import * as commentApi from '@api/commentApi';
+
+export const getComment = createAsyncThunk('comment/get', async ({ rejectWithValue }) => {
+  try {
+    const response = await commentApi.fetchGet();
+    return response.data;
+  } catch (error) {
+    return rejectWithValue(error.response);
+  }
+});
+
+export const modifyComment = createAsyncThunk('comment/get', async (id, { rejectWithValue }) => {
+  try {
+    const response = await commentApi.fetchModify();
+    return response.data;
+  } catch (error) {
+    return rejectWithValue(error.response);
+  }
+});
+
+export const deleteComment = createAsyncThunk('comment/get', async (id, { rejectWithValue }) => {
+  try {
+    const response = await commentApi.fetchDelete();
+    return response.data;
+  } catch (error) {
+    return rejectWithValue(error.response);
+  }
+});

--- a/kh/src/redux/reducers/commentSlice.js
+++ b/kh/src/redux/reducers/commentSlice.js
@@ -1,10 +1,28 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { deleteComment, getComment, modifyComment } from '@redux/actions/comment';
 
-const initialState = {};
+const initialState = {
+  comments: [],
+};
+
+function isPendingAction(action) {
+  return action.type.endsWith('/pending');
+}
+
+function isRejectedAction(action) {
+  return action.type.endsWith('/rejected');
+}
 
 export const commentSlice = createSlice({
   name: 'comment',
   initialState,
   reducers: {},
-  extraReducers: builder => {},
+  extraReducers: builder => {
+    builder
+      .addCase(getComment.fulfilled, (state, action) => {})
+      .addCase(deleteComment.fulfilled, (state, action) => {})
+      .addCase(modifyComment.fulfilled, (state, action) => {})
+      .addMatcher(isPendingAction, state => {})
+      .addMatcher(isRejectedAction, (state, action) => {});
+  },
 });


### PR DESCRIPTION
api 비동기 요청 관련 redux 기본구조만 구현했습니다.
- `addMatcher()` 함수를 사용하여 pending될때와 rejected될 때를 합쳤습니다
